### PR TITLE
Make jwalk an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dircpy"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Johann Woelper <woelper@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ keywords = ["copy", "recursive", "filesystem", "file"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["jwalk"]
+
 [dependencies]
 walkdir = "2.3.2"
 log = "0.4.16"
 # rayon = "1.4.0"
-jwalk = "0.6.0"
+jwalk = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 unzip = "0.1.0"

--- a/benches/copy_rustlang.rs
+++ b/benches/copy_rustlang.rs
@@ -88,6 +88,7 @@ fn test_dircpy_single(c: &mut Criterion) {
 
 fn test_dircpy_parallel(c: &mut Criterion) {
     // One-time setup code goes here
+    #[cfg(feature = "jwalk")]
     c.bench_function("cpy multi-threaded", |b| {
         // Per-sample (note that a sample can be many iterations) setup goes here
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use walkdir::WalkDir;
+#[cfg(feature = "jwalk")]
 use jwalk::WalkDir as JWalkDir;
 
 #[cfg(test)]
@@ -91,6 +92,7 @@ fn is_filesize_different(file_a: &Path, file_b: &Path) -> bool {
     }
 }
 
+#[cfg(feature = "jwalk")]
 fn copy_file(source: &Path, options: CopyBuilder) -> Result<(), std::io::Error> {
     let abs_source = options.source.canonicalize()?;
     let abs_dest = options.destination.canonicalize()?;
@@ -326,6 +328,7 @@ impl CopyBuilder {
 
     /// Execute the copy operation in parallel. The usage of this function is discouraged
     /// until proven to work faster.
+    #[cfg(feature = "jwalk")]
     pub fn run_par(&self) -> Result<(), std::io::Error> {
         if !self.destination.is_dir() {
             debug!("MKDIR {:?}", &self.destination);


### PR DESCRIPTION
Hi there, thanks for the handy crate!

This PR makes depending on `jwalk` (and rayon, crossbeam, and its other dependencies) optional.

By default it's still enabled, but you can now disable it with this in you Cargo.toml:

```rust
dircpy = { version = "0.3", default-features = false }
```

If you do add `default-features = false`, then [`CopyBuilder::run_par`](https://docs.rs/dircpy/latest/dircpy/struct.CopyBuilder.html#method.run_par) disappears, but you might get improved compile times.

I've also bumped the version number to 0.3.10 – no rush but would appreciate this being published at some point.