### PR TITLE
Improved handling of multiple patterns in include_filters (dircpy issue #8)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,16 +275,11 @@ impl CopyBuilder {
                     }
                 }
 
-                let mut include_filter_found = false;
-
-                for f in &self.include_filters {
-                    if entry.path().to_string_lossy().contains(f) {
-                        include_filter_found = true;
-                        break;
-                    }
-                }
-
-                if !include_filter_found && !self.include_filters.is_empty() {
+                if !self
+                    .include_filters
+                    .iter()
+                    .any(|f| entry.path().to_string_lossy().contains(f))
+                {
                     continue 'files;
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,10 +275,17 @@ impl CopyBuilder {
                     }
                 }
 
+                let mut include_filter_found = false;
+
                 for f in &self.include_filters {
-                    if !entry.path().to_string_lossy().contains(f) {
-                        continue 'files;
+                    if entry.path().to_string_lossy().contains(f) {
+                        include_filter_found = true;
+                        break;
                     }
+                }
+
+                if !include_filter_found {
+                    continue 'files;
                 }
 
                 // File is not present: copy it in any case

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ impl CopyBuilder {
                     }
                 }
 
-                if !include_filter_found {
+                if !include_filter_found && !self.include_filters.is_empty() {
                     continue 'files;
                 }
 


### PR DESCRIPTION
Hi there,

I'm following up on an issue I just opened ([#8](https://github.com/woelper/dircpy/issues/8)).

The issue arises when there are multiple patterns defined in the include_filters vector. In the current implementation, the loop iterates through these patterns. If the first pattern doesn't match the entry's filename, the loop skips processing the remaining patterns and moves on to the next file.

To address this, I've modified the code to ensure all patterns in include_filters are compared against the entry's filename before continuing the loop. This guarantees that only files matching any of the included patterns are processed.
This fix has resolved the issue I was experiencing.

I've attached the modified code for your reference (if applicable). Please let me know if you have any questions or require further clarification.

Thanks,
Giovanni