### PR TITLE
fix: include list logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,10 +275,11 @@ impl CopyBuilder {
                     }
                 }
 
-                if !self.include_filters.is_empty() && !self
-                    .include_filters
-                    .iter()
-                    .any(|f| entry.path().to_string_lossy().contains(f))
+                if !self.include_filters.is_empty()
+                    && !self
+                        .include_filters
+                        .iter()
+                        .any(|f| entry.path().to_string_lossy().contains(f))
                 {
                     continue 'files;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ impl CopyBuilder {
                     }
                 }
 
-                if !self
+                if !self.include_filters.is_empty() && !self
                     .include_filters
                     .iter()
                     .any(|f| entry.path().to_string_lossy().contains(f))


### PR DESCRIPTION
Check if the include filters actually has filters to iterate, or else `any()` always returns `false` and the branch is always taken.